### PR TITLE
RDKB-58910, RDKB-60007 : Use the Ipv6 address set by WanManager

### DIFF
--- a/source/TelcoVoiceManager/telcovoicemgr_nw_monitor.c
+++ b/source/TelcoVoiceManager/telcovoicemgr_nw_monitor.c
@@ -56,7 +56,7 @@
 #define SYSEVENT_IPV4_CONNECTION_STATE "ipv4_connection_state"
 #define SYSEVENT_IPV6_CONNECTION_STATE "ipv6_connection_state"
 #define SYSEVENT_IPV4_IP_ADDRESS "ipv4_%s_ipaddr"
-#define SYSEVENT_IPV6_PREFIX "ipv6_prefix"
+#define SYSEVENT_IPV6_IP_ADDRESS "tr_%s_dhcpv6_client_v6addr"
 /*WAN/LAN specific sysevent fieldnames*/
 #define SYSEVENT_CURRENT_WAN_IFNAME "current_wan_ifname"
 #define SYSEVENT_LAN_STATUS "lan-status"
@@ -452,14 +452,12 @@ static void event_set_wan_status (void)
         {
             if (!strcmp(conState, "up"))
             {
-                if (sysevent_get(sysevent_rw_fd, sysevent_token, SYSEVENT_IPV6_PREFIX, ipAddr, sizeof(ipAddr)) == 0)
+                if (sysevent_get(sysevent_rw_fd, sysevent_token, SYSEVENT_CURRENT_WAN_IFNAME, ifName, sizeof(ifName)) == 0)
                 {
-                    char *ipv6_addr;
-                    CcspTraceInfo(("%s:: IPv6 Prefix Address ----> { %s}\n", __FUNCTION__, ipAddr));
-                    ipv6_addr = strchr(ipAddr, '/');
-                    if(ipv6_addr != NULL)
+                    char sysevent_param_name[32] = {0};
+                    snprintf(sysevent_param_name, sizeof(sysevent_param_name), SYSEVENT_IPV6_IP_ADDRESS, ifName);
+                    if (sysevent_get(sysevent_rw_fd, sysevent_token, sysevent_param_name, ipAddr, sizeof(ipAddr)) == 0)
                     {
-                        strncpy(ipv6_addr, "1",2);
                         CcspTraceInfo(("%s:: WAN IPv6 Address updated! { %s }\n", __FUNCTION__, ipAddr));
                         CcspTraceNotice(("TELCOVOICEMANAGER_IPV6_WANUP :: Voice Manager: IPV6 WAN up\n"));
                         //update the SKBmark reading from Wan Manager

--- a/source/TelcoVoiceManager/telcovoicemgr_nw_monitor.c
+++ b/source/TelcoVoiceManager/telcovoicemgr_nw_monitor.c
@@ -463,11 +463,11 @@ static void event_set_wan_status (void)
             {
                 if (sysevent_get(sysevent_rw_fd, sysevent_token, SYSEVENT_CURRENT_WAN_IFNAME, ifName, sizeof(ifName)) == 0)
                 {
-                    char sysevent_param_name[32] = {0};
+                    char sysevent_param_name[128] = {0};
                     snprintf(sysevent_param_name, sizeof(sysevent_param_name), SYSEVENT_IPV6_IP_ADDRESS, ifName);
                     if (sysevent_get(sysevent_rw_fd, sysevent_token, sysevent_param_name, ipAddr, sizeof(ipAddr)) == 0)
                     {
-                        CcspTraceInfo(("%s:: WAN IPv6 Address updated! { %s }\n", __FUNCTION__, ipAddr));
+                        CcspTraceInfo(("%s:: WAN IPv6 Address sysevent %s updated!  { %s }\n", __FUNCTION__, sysevent_param_name , ipAddr));
                         CcspTraceNotice(("TELCOVOICEMANAGER_IPV6_WANUP :: Voice Manager: IPV6 WAN up\n"));
                         //update the SKBmark reading from Wan Manager
 


### PR DESCRIPTION
Pull request overview
Updates Telco Voice Manager’s IPv6 WAN-up handling to bind voice services to the IPv6 address assigned on the current WAN interface (as provided by WanManager via sysevent), rather than deriving an address from the LAN-bridge IPv6 prefix.

Changes:

Replaced use of the global ipv6_prefix sysevent with an interface-specific IPv6 address sysevent key template.
On IPv6 WAN-up, retrieves current_wan_ifname and uses it to build the sysevent parameter name for the WAN IPv6 address.
This PR is dependent on the following related PRs:
https://github.com/rdkcentral/telco-voice-manager/pull/5
https://github.com/rdkcentral/utopia/pull/69
https://github.com/rdkcentral/wan-manager/pull/79
https://github.com/rdkcentral/provisioning-and-management/pull/127
https://github.com/rdkcentral/xconf-client/pull/20
https://github.com/rdkcentral/test-and-diagnostic/pull/172
https://github.com/rdk-gdcs/firewall/pull/5