### PR TITLE
RDKCOM-5538: RDKBDEV-3387 [TR104] String parameter accepts invalid boundary values

### DIFF
--- a/config/RdkTelcoVoiceManager_v2.xml
+++ b/config/RdkTelcoVoiceManager_v2.xml
@@ -293,12 +293,12 @@
                 </parameter>
                 <parameter>
                     <name>NetworkConnectionModes</name>
-                    <type>String(255)</type>
+                    <type>string(255)</type>
                     <syntax>string</syntax>
                 </parameter>
                 <parameter>
                     <name>UserConnectionModes</name>
-                    <type>String(255)</type>
+                    <type>string(255)</type>
                     <syntax>string</syntax>
                 </parameter>
                 <parameter>
@@ -332,17 +332,17 @@
                    <parameters>
                         <parameter>
                             <name>Extensions</name>
-                            <type>String(255)</type>
+                            <type>string(255)</type>
                             <syntax>string</syntax>
                         </parameter>
                         <parameter>
                             <name>URISchemes</name>
-                            <type>String(255)</type>
+                            <type>string(255)</type>
                             <syntax>string</syntax>
                         </parameter>
                         <parameter>
                             <name>EventTypes</name>
-                            <type>String(255)</type>
+                            <type>string(255)</type>
                             <syntax>string</syntax>
                         </parameter>
                         <parameter>
@@ -352,7 +352,7 @@
                         </parameter>
                         <parameter>
                             <name>TLSAuthenticationKeySizes</name>
-                            <type>String(255)</type>
+                            <type>string(255)</type>
                             <syntax>string</syntax>
                         </parameter>
                         <parameter>
@@ -362,7 +362,7 @@
                         </parameter>
                         <parameter>
                             <name>TLSEncryptionKeySizes</name>
-                            <type>String(255)</type>
+                            <type>string(255)</type>
                             <syntax>string</syntax>
                         </parameter>
                         <parameter>
@@ -382,17 +382,17 @@
                    <parameters>
                         <parameter>
                             <name>Extensions</name>
-                            <type>String(255)</type>
+                            <type>string(255)</type>
                             <syntax>string</syntax>
                         </parameter>
                         <parameter>
                             <name>URISchemes</name>
-                            <type>String(255)</type>
+                            <type>string(255)</type>
                             <syntax>string</syntax>
                         </parameter>
                         <parameter>
                             <name>EventTypes</name>
-                            <type>String(255)</type>
+                            <type>string(255)</type>
                             <syntax>string</syntax>
                         </parameter>
                         <parameter>
@@ -402,7 +402,7 @@
                         </parameter>
                         <parameter>
                             <name>TLSAuthenticationKeySizes</name>
-                            <type>String(255)</type>
+                            <type>string(255)</type>
                             <syntax>string</syntax>
                         </parameter>
                         <parameter>
@@ -412,7 +412,7 @@
                         </parameter>
                         <parameter>
                             <name>TLSEncryptionKeySizes</name>
-                            <type>String(255)</type>
+                            <type>string(255)</type>
                             <syntax>string</syntax>
                         </parameter>
                         <parameter>
@@ -433,7 +433,7 @@
                <parameters>
                     <parameter>
                         <name>Extensions</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                     </parameter>
                </parameters>
@@ -559,7 +559,7 @@
                     </parameter>
                     <parameter>
                         <name>PacketizationPeriod</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
@@ -579,7 +579,7 @@
                 <parameters>
                     <parameter>
                         <name>QIModelsSupported</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
@@ -606,13 +606,13 @@
            <parameters>
                 <parameter>
                     <name>WANPortRange</name>
-                    <type>String(255)</type>
+                    <type>string(255)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
                 <parameter>
                     <name>LANPortRange</name>
-                    <type>String(255)</type>
+                    <type>string(255)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
@@ -661,12 +661,12 @@
                     </parameter>
                     <parameter>
                         <name>Name</name>
-                        <type>String(64)</type>
+                        <type>string(64)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
                         <name>ToneEventProfile</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -738,19 +738,19 @@
                     </parameter>
                     <parameter>
                         <name>OutboundOnlyBChannels</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>InboundOnlyBChannels</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>BidirectionalBChannels</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -795,12 +795,12 @@
                     </parameter>
                     <parameter>
                         <name>Name</name>
-                        <type>String(64)</type>
+                        <type>string(64)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
                         <name>ToneEventProfile</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -854,19 +854,19 @@
                     </parameter>
                     <parameter>
                         <name>OutboundOnlyBChannels</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>InboundOnlyBChannels</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>BidirectionalBChannels</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -890,7 +890,7 @@
            <parameters>
                 <parameter>
                     <name>Region</name>
-                    <type>String(2)</type>
+                    <type>string(2)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
@@ -935,12 +935,12 @@
                     </parameter>
                     <parameter>
                         <name>Name</name>
-                        <type>String(64)</type>
+                        <type>string(64)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
                         <name>ToneEventProfile</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -1067,12 +1067,12 @@
                     </parameter>
                     <parameter>
                         <name>Name</name>
-                        <type>String(64)</type>
+                        <type>string(64)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
                         <name>ToneEventProfile</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -1223,7 +1223,7 @@
                         </parameter>
                         <parameter>
                             <name>Cadence</name>
-                            <type>String(255)</type>
+                            <type>string(255)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -1276,12 +1276,12 @@
                     </parameter>
                     <parameter>
                         <name>Name</name>
-                        <type>String(64)</type>
+                        <type>string(64)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
                         <name>ToneEventProfile</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -1292,7 +1292,7 @@
                     </parameter>
                     <parameter>
                         <name>RFPI</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
@@ -1303,7 +1303,7 @@
                     </parameter>
                     <parameter>
                         <name>PIN</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -1343,17 +1343,17 @@
                     </parameter>
                     <parameter>
                         <name>FirmwareVersion</name>
-                        <type>String(20)</type>
+                        <type>string(20)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
                         <name>EepromVersion</name>
-                        <type>String(20)</type>
+                        <type>string(20)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
                         <name>HardwareVersion</name>
-                        <type>String(20)</type>
+                        <type>string(20)</type>
                         <syntax>string</syntax>
                     </parameter>
                 </parameters>
@@ -1433,7 +1433,7 @@
                     </parameter>
                     <parameter>
                         <name>CodecList</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -1444,7 +1444,7 @@
                     </parameter>
                     <parameter>
                         <name>IPUI</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
@@ -1454,17 +1454,17 @@
                     </parameter>
                     <parameter>
                         <name>IPEI</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
                         <name>PARK</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
                         <name>BaseAttachedTo</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
@@ -1474,7 +1474,7 @@
                     </parameter>
                     <parameter>
                         <name>SubscriptionTime</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
@@ -1485,12 +1485,12 @@
                     </parameter>
                     <parameter>
                         <name>HardwareVersion</name>
-                        <type>String(20)</type>
+                        <type>string(20)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
                         <name>SoftwareVersion</name>
-                        <type>String(20)</type>
+                        <type>string(20)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
@@ -1500,12 +1500,12 @@
                     </parameter>
                     <parameter>
                         <name>LastUpdateDateTime</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
                         <name>OperatorName</name>
-                        <type>String(32)</type>
+                        <type>string(32)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -1576,19 +1576,19 @@
                     </parameter>
                     <parameter>
                         <name>AuthUserName</name>
-                        <type>String(128)</type>
+                        <type>string(128)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>AuthPassword</name>
-                        <type>String(128)</type>
+                        <type>string(128)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>Network</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -1600,7 +1600,7 @@
                     </parameter>
                     <parameter>
                         <name>RegisterURI</name>
-                        <type>String(389)</type>
+                        <type>string(389)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -1667,7 +1667,7 @@
                         </parameter>
                         <parameter>
                             <name>IPAddress</name>
-                            <type>String(45)</type>
+                            <type>string(45)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -1679,13 +1679,13 @@
                         </parameter>
                         <parameter>
                             <name>ContactURI</name>
-                            <type>String(256)</type>
+                            <type>string(256)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
                         <parameter>
                             <name>ExpireTime</name>
-                            <type>String(255)</type>
+                            <type>string(255)</type>
                             <syntax>string</syntax>
                         </parameter>
                         <parameter>
@@ -1696,7 +1696,7 @@
                         </parameter>
                         <parameter>
                             <name>UserAgent</name>
-                            <type>String(256)</type>
+                            <type>string(256)</type>
                             <syntax>string</syntax>
                         </parameter>
                     </parameters>
@@ -1733,18 +1733,18 @@
                         </parameter>
                         <parameter>
                             <name>Event</name>
-                            <type>String(32)</type>
+                            <type>string(32)</type>
                             <syntax>string</syntax>
                         </parameter>
                         <parameter>
                             <name>AuthUserName</name>
-                            <type>String(128)</type>
+                            <type>string(128)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
                         <parameter>
                             <name>AuthPassword</name>
-                            <type>String(128)</type>
+                            <type>string(128)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -1799,7 +1799,7 @@
                     </parameter>
                     <parameter>
                         <name>ProxyServer</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -1817,7 +1817,7 @@
                     </parameter>
                     <parameter>
                         <name>RegistrarServer</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                         <restrictedChars>&lt;&gt;%`|'</restrictedChars>
@@ -1836,18 +1836,18 @@
                     </parameter>
                     <parameter>
                         <name>ServerDomain</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>ChosenDomain</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
                         <name>ChosenIPAddress</name>
-                        <type>String(45)</type>
+                        <type>string(45)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
@@ -1857,7 +1857,7 @@
                     </parameter>
                     <parameter>
                         <name>UserAgentDomain</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                         <restrictedChars>&lt;&gt;%`|'</restrictedChars>
@@ -1876,14 +1876,14 @@
                     </parameter>
                     <parameter>
                         <name>OutboundProxy</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                         <restrictedChars>&lt;&gt;%`|'</restrictedChars>
                     </parameter>
                     <parameter>
                         <name>OutboundProxyResolvedAddress</name>
-                        <type>String(45)</type>
+                        <type>string(45)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
@@ -1905,7 +1905,7 @@
                     </parameter>
                     <parameter>
                         <name>STUNServer</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -1923,7 +1923,7 @@
                     </parameter>
                     <parameter>
                         <name>Organization</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -1935,7 +1935,7 @@
                     </parameter>
                     <parameter>
                         <name>Realm</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -2055,13 +2055,13 @@
                     </parameter>
                     <parameter>
                         <name>InboundAuthUsername</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>InboundAuthPassword</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -2091,7 +2091,7 @@
                     </parameter>
                     <parameter>
                         <name>ConferenceCallDomainURI</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -2126,13 +2126,13 @@
                     </parameter>
                     <parameter>
                         <name>VoIPProfile</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>CodecList</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -2244,7 +2244,7 @@
                         </parameter>
                         <parameter>
                             <name>Domain</name>
-                            <type>String(256)</type>
+                            <type>string(256)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -2268,7 +2268,7 @@
                         </parameter>
                         <parameter>
                             <name>IPAddresses</name>
-                            <type>String(255)</type>
+                            <type>string(255)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -2308,13 +2308,13 @@
                         </parameter>
                         <parameter>
                             <name>Event</name>
-                            <type>String(32)</type>
+                            <type>string(32)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
                         <parameter>
                             <name>Notifier</name>
-                            <type>String(256)</type>
+                            <type>string(256)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -2378,13 +2378,13 @@
                         </parameter>
                         <parameter>
                             <name>TextMessage</name>
-                            <type>String(64)</type>
+                            <type>string(64)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
                         <parameter>
                             <name>Tone</name>
-                            <type>String(256)</type>
+                            <type>string(256)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -2436,7 +2436,7 @@
                     </parameter>
                     <parameter>
                         <name>ProxyIPAddress</name>
-                        <type>String(45)</type>
+                        <type>string(45)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -2448,12 +2448,12 @@
                     </parameter>
                     <parameter>
                         <name>ContactURI</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
                         <name>VoIPProfile</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -2509,7 +2509,7 @@
                     </parameter>
                     <parameter>
                         <name>RegistrarIPAddress</name>
-                        <type>String(45)</type>
+                        <type>string(45)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -2533,25 +2533,25 @@
                     </parameter>
                     <parameter>
                         <name>Organization</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>Realm</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>VoIPProfile</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>ContactURI</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                     </parameter>
                </parameters>
@@ -2611,14 +2611,14 @@
                         </parameter>
                         <parameter>
                             <name>AuthUserName</name>
-                            <type>String(128)</type>
+                            <type>string(128)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                             <restrictedChars>&lt;&gt;%`|'</restrictedChars>
                         </parameter>
                         <parameter>
                             <name>AuthPassword</name>
-                            <type>String(128)</type>
+                            <type>string(128)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -2629,26 +2629,26 @@
                         </parameter>
                         <parameter>
                             <name>URI</name>
-                            <type>String(389)</type>
+                            <type>string(389)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                             <restrictedChars>&lt;&gt;%`|'</restrictedChars>
                         </parameter>
                         <parameter>
                             <name>Domain</name>
-                            <type>String(256)</type>
+                            <type>string(256)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
                         <parameter>
                             <name>CodecList</name>
-                            <type>String(255)</type>
+                            <type>string(255)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
                         <parameter>
                             <name>VoIPProfile</name>
-                            <type>String(256)</type>
+                            <type>string(256)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -2697,7 +2697,7 @@
                             </parameter>
                             <parameter>
                                 <name>IPAddress</name>
-                                <type>String(45)</type>
+                                <type>string(45)</type>
                                 <syntax>string</syntax>
                                 <writable>true</writable>
                             </parameter>
@@ -2709,18 +2709,18 @@
                             </parameter>
                             <parameter>
                                 <name>ContactURI</name>
-                                <type>String(256)</type>
+                                <type>string(256)</type>
                                 <syntax>string</syntax>
                                 <writable>true</writable>
                             </parameter>
                             <parameter>
                                 <name>ExpireTime</name>
-                                <type>String(255)</type>
+                                <type>string(255)</type>
                                 <syntax>string</syntax>
                             </parameter>
                             <parameter>
                                 <name>UserAgent</name>
-                                <type>String(64)</type>
+                                <type>string(64)</type>
                                 <syntax>string</syntax>
                                 <writable>true</writable>
                             </parameter>
@@ -2793,19 +2793,19 @@
                     </parameter>
                     <parameter>
                         <name>Domain</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>User</name>
-                        <type>String(64)</type>
+                        <type>string(64)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>Network</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -2864,7 +2864,7 @@
                     </parameter>
                     <parameter>
                         <name>CallAgent1</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -2876,7 +2876,7 @@
                     </parameter>
                     <parameter>
                         <name>CallAgent2</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -2936,7 +2936,7 @@
                     </parameter>
                     <parameter>
                         <name>STUNServer</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -2960,13 +2960,13 @@
                     </parameter>
                     <parameter>
                         <name>VoIPProfile</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>CodecList</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -3029,25 +3029,25 @@
                     </parameter>
                     <parameter>
                         <name>AuthPassword</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>SendersID</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>Network</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>H323ID</name>
-                        <type>String(32)</type>
+                        <type>string(32)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -3106,7 +3106,7 @@
                     </parameter>
                     <parameter>
                         <name>Gatekeeper</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -3118,7 +3118,7 @@
                     </parameter>
                     <parameter>
                         <name>GatekeeperID</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -3154,7 +3154,7 @@
                     </parameter>
                     <parameter>
                         <name>STUNServer</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -3178,13 +3178,13 @@
                     </parameter>
                     <parameter>
                         <name>VoIPProfile</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>CodecList</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -3244,13 +3244,13 @@
                 </parameter>
                 <parameter>
                     <name>Name</name>
-                    <type>String(16)</type>
+                    <type>string(16)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
                 <parameter>
                     <name>DDIRange</name>
-                    <type>String(255)</type>
+                    <type>string(255)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
@@ -3286,7 +3286,7 @@
                 </parameter>
                 <parameter>
                     <name>Provider</name>
-                    <type>String(256)</type>
+                    <type>string(256)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
@@ -3368,20 +3368,20 @@
                    </parameter>
                    <parameter>
                        <name>DirectoryNumber</name>
-                       <type>String(32)</type>
+                       <type>string(32)</type>
                        <syntax>string</syntax>
                        <writable>true</writable>
                        <restrictedChars>&lt;&gt;%`|'</restrictedChars>
                    </parameter>
                    <parameter>
                        <name>Provider</name>
-                       <type>String(256)</type>
+                       <type>string(256)</type>
                        <syntax>string</syntax>
                        <writable>true</writable>
                    </parameter>
                    <parameter>
                        <name>CallingFeatures</name>
-                       <type>String(256)</type>
+                       <type>string(256)</type>
                        <syntax>string</syntax>
                        <writable>true</writable>
                    </parameter>
@@ -3570,37 +3570,37 @@
                     </parameter>
                     <parameter>
                         <name>Name</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>ExtensionNumber</name>
-                        <type>String(32)</type>
+                        <type>string(32)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>Provider</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>NumberingPlan</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
 		    <parameter>
                         <name>X_RDK_FacilityAction</name>
-                        <type>String(64)</type>
+                        <type>string(64)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>X_RDK_FacilityActionArgument</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -3611,7 +3611,7 @@
                     </parameter>
                     <parameter>
                         <name>CallingFeatures</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -3632,7 +3632,7 @@
                     </parameter>
                     <parameter>
                         <name>VoiceMail</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -3793,7 +3793,7 @@
                     </parameter>
                     <parameter>
                         <name>Extensions</name>
-                        <type>String(2048)</type>
+                        <type>string(2048)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -3863,7 +3863,7 @@
                     </parameter>
                     <parameter>
                         <name>SMTPServerAddress</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -3875,13 +3875,13 @@
                     </parameter>
                     <parameter>
                         <name>SMTPUser</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>SMTPPassword</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -3893,7 +3893,7 @@
                     </parameter>
                     <parameter>
                         <name>SMTPFrom</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -3933,13 +3933,13 @@
                     </parameter>
                     <parameter>
                         <name>Line</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>Extension</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -3993,19 +3993,19 @@
                     </parameter>
                     <parameter>
                         <name>CLIPNoScreeningNumber</name>
-                        <type>String(32)</type>
+                        <type>string(32)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>Extension</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>Line</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -4069,13 +4069,13 @@
                     </parameter>
                     <parameter>
                         <name>TerminationDigit</name>
-                        <type>String(1)</type>
+                        <type>string(1)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>InvalidNumberTone</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -4120,7 +4120,7 @@
                         </parameter>
                         <parameter>
                             <name>PrefixRange</name>
-                            <type>String(42)</type>
+                            <type>string(42)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -4150,19 +4150,19 @@
                         </parameter>
                         <parameter>
                             <name>DialTone</name>
-                            <type>String(256)</type>
+                            <type>string(256)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
                         <parameter>
                             <name>FacilityAction</name>
-                            <type>String(64)</type>
+                            <type>string(64)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
                         <parameter>
                             <name>FacilityActionArgument</name>
-                            <type>String(256)</type>
+                            <type>string(256)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -4226,7 +4226,7 @@
                         </parameter>
                         <parameter>
                             <name>CallForwardUnconditionalNumber</name>
-                            <type>String(32)</type>
+                            <type>string(32)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -4238,7 +4238,7 @@
                         </parameter>
                         <parameter>
                             <name>CallForwardOnBusyNumber</name>
-                            <type>String(32)</type>
+                            <type>string(32)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -4256,7 +4256,7 @@
                         </parameter>
                         <parameter>
                             <name>CallForwardOnNoAnswerNumber</name>
-                            <type>String(32)</type>
+                            <type>string(32)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -4407,25 +4407,25 @@
                             </parameter>
                             <parameter>
                                 <name>Day</name>
-                                <type>String(255)</type>
+                                <type>string(255)</type>
                                 <syntax>string</syntax>
                                 <writable>true</writable>
                             </parameter>
                             <parameter>
                                 <name>StartTime</name>
-                                <type>String(5)</type>
+                                <type>string(5)</type>
                                 <syntax>string</syntax>
                                 <writable>true</writable>
                             </parameter>
                             <parameter>
                                 <name>EndTime</name>
-                                <type>String(5)</type>
+                                <type>string(5)</type>
                                 <syntax>string</syntax>
                                 <writable>true</writable>
                             </parameter>
                             <parameter>
                                 <name>ForwardedToNumber</name>
-                                <type>String(32)</type>
+                                <type>string(32)</type>
                                 <syntax>string</syntax>
                                 <writable>true</writable>
                             </parameter>
@@ -4463,13 +4463,13 @@
                             </parameter>
                             <parameter>
                                 <name>CallingNumber</name>
-                                <type>String(32)</type>
+                                <type>string(32)</type>
                                 <syntax>string</syntax>
                                 <writable>true</writable>
                             </parameter>
                             <parameter>
                                 <name>ForwardedToNumber</name>
-                                <type>String(32)</type>
+                                <type>string(32)</type>
                                 <syntax>string</syntax>
                                 <writable>true</writable>
                             </parameter>
@@ -4507,7 +4507,7 @@
                             </parameter>
                             <parameter>
                                 <name>CallingNumber</name>
-                                <type>String(32)</type>
+                                <type>string(32)</type>
                                 <syntax>string</syntax>
                                 <writable>true</writable>
                             </parameter>
@@ -4553,7 +4553,7 @@
                             </parameter>
                             <parameter>
                                 <name>Number</name>
-                                <type>String(32)</type>
+                                <type>string(32)</type>
                                 <syntax>string</syntax>
                                 <writable>true</writable>
                             </parameter>
@@ -4603,7 +4603,7 @@
                             </parameter>
                             <parameter>
                                 <name>EMailAddress</name>
-                                <type>String(255)</type>
+                                <type>string(255)</type>
                                 <syntax>string</syntax>
                                 <writable>true</writable>
                             </parameter>
@@ -4665,7 +4665,7 @@
                 </parameter>
                 <parameter>
                     <name>OperationalStatusReason</name>
-                    <type>String(256)</type>
+                    <type>string(256)</type>
                     <syntax>string</syntax>
                 </parameter>
                 <parameter>
@@ -4694,12 +4694,12 @@
                 </parameter>
                 <parameter>
                     <name>NetworkIPAddress</name>
-                    <type>String(45)</type>
+                    <type>string(45)</type>
                     <syntax>string</syntax>
                 </parameter>
                 <parameter>
                     <name>InterworkingRuleSetURI</name>
-                    <type>String(256)</type>
+                    <type>string(256)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
@@ -4711,13 +4711,13 @@
                 </parameter>
                 <parameter>
                     <name>InterworkingRuleSetTime</name>
-                    <type>String(255)</type>
+                    <type>string(255)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
                 <parameter>
                     <name>FirewallRuleSetURI</name>
-                    <type>String(256)</type>
+                    <type>string(256)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
@@ -4729,31 +4729,31 @@
                 </parameter>
                 <parameter>
                     <name>FirewallRuleSetTime</name>
-                    <type>String(255)</type>
+                    <type>string(255)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
                 <parameter>
                     <name>InterworkName</name>
-                    <type>String(256)</type>
+                    <type>string(256)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
                 <parameter>
                     <name>ProxyServer</name>
-                    <type>String(256)</type>
+                    <type>string(256)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
                 <parameter>
                     <name>Networks</name>
-                    <type>String(255)</type>
+                    <type>string(255)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
                 <parameter>
                     <name>E164Client</name>
-                    <type>String(256)</type>
+                    <type>string(256)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
@@ -4791,13 +4791,13 @@
                     </parameter>
                     <parameter>
                         <name>Registrar</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>Network</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -4831,7 +4831,7 @@
                     </parameter>
                     <parameter>
                         <name>Status</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
@@ -4842,34 +4842,34 @@
                     </parameter>
                     <parameter>
                         <name>StatusDescription</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
                         <name>LastTime</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
                         <name>Origin</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
                         <name>NetworkConnection</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>UserConnection</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>DigitMap</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -4914,37 +4914,37 @@
                 </parameter>
                 <parameter>
                     <name>CallingPartyNumber</name>
-                    <type>String(256)</type>
+                    <type>string(256)</type>
                     <syntax>string</syntax>
                 </parameter>
                 <parameter>
                     <name>CalledPartyNumber</name>
-                    <type>String(256)</type>
+                    <type>string(256)</type>
                     <syntax>string</syntax>
                 </parameter>
                 <parameter>
                     <name>Source</name>
-                    <type>String(256)</type>
+                    <type>string(256)</type>
                     <syntax>string</syntax>
                 </parameter>
                 <parameter>
                     <name>Destination</name>
-                    <type>String(256)</type>
+                    <type>string(256)</type>
                     <syntax>string</syntax>
                 </parameter>
                 <parameter>
                     <name>RemoteParty</name>
-                    <type>String(32)</type>
+                    <type>string(32)</type>
                     <syntax>string</syntax>
                 </parameter>
                 <parameter>
                     <name>UsedLine</name>
-                    <type>String(256)</type>
+                    <type>string(256)</type>
                     <syntax>string</syntax>
                 </parameter>
                 <parameter>
                     <name>UsedExtensions</name>
-                    <type>String(255)</type>
+                    <type>string(255)</type>
                     <syntax>string</syntax>
                 </parameter>
                 <parameter>
@@ -4954,7 +4954,7 @@
                 </parameter>
                 <parameter>
                     <name>Start</name>
-                    <type>String(255)</type>
+                    <type>string(255)</type>
                     <syntax>string</syntax>
                 </parameter>
                 <parameter>
@@ -5032,7 +5032,7 @@
                     </parameter>
                     <parameter>
                         <name>Start</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                     </parameter>
                     <parameter>
@@ -5042,7 +5042,7 @@
                     </parameter>
                     <parameter>
                         <name>SessionID</name>
-                        <type>String(16)</type>
+                        <type>string(16)</type>
                         <syntax>string</syntax>
                     </parameter>
                 </parameters>
@@ -5086,7 +5086,7 @@
                        <parameters>
                             <parameter>
                                 <name>FarEndIPAddress</name>
-                                <type>String(45)</type>
+                                <type>string(45)</type>
                                 <syntax>string</syntax>
                             </parameter>
                             <parameter>
@@ -5221,7 +5221,7 @@
                             <parameters>
                                 <parameter>
                                     <name>Codec</name>
-                                    <type>String(256)</type>
+                                    <type>string(256)</type>
                                     <syntax>string</syntax>
                                 </parameter>
                                 <parameter>
@@ -5252,7 +5252,7 @@
                             <parameters>
                                 <parameter>
                                     <name>Codec</name>
-                                    <type>String(256)</type>
+                                    <type>string(256)</type>
                                     <syntax>string</syntax>
                                 </parameter>
                                 <parameter>
@@ -5289,17 +5289,17 @@
                         <parameters>
                             <parameter>
                                 <name>VoIPQualityIndicator</name>
-                                <type>String(255)</type>
+                                <type>string(255)</type>
                                 <syntax>string</syntax>
                             </parameter>
                             <parameter>
                                 <name>WorstVoIPQualityIndicatorsValues</name>
-                                <type>String(255)</type>
+                                <type>string(255)</type>
                                 <syntax>string</syntax>
                             </parameter>
                             <parameter>
                                 <name>WorstVoIPQualityIndicatorTimestamps</name>
-                                <type>String(255)</type>
+                                <type>string(255)</type>
                                 <syntax>string</syntax>
                             </parameter>
                         </parameters>
@@ -5321,7 +5321,7 @@
                        <parameters>
                             <parameter>
                                 <name>FarEndIPAddress</name>
-                                <type>String(45)</type>
+                                <type>string(45)</type>
                                 <syntax>string</syntax>
                             </parameter>
                             <parameter>
@@ -5456,7 +5456,7 @@
                             <parameters>
                                 <parameter>
                                     <name>Codec</name>
-                                    <type>String(256)</type>
+                                    <type>string(256)</type>
                                     <syntax>string</syntax>
                                 </parameter>
                                 <parameter>
@@ -5487,7 +5487,7 @@
                             <parameters>
                                 <parameter>
                                     <name>Codec</name>
-                                    <type>String(256)</type>
+                                    <type>string(256)</type>
                                     <syntax>string</syntax>
                                 </parameter>
                                 <parameter>
@@ -5523,17 +5523,17 @@
                         <parameters>
                             <parameter>
                                 <name>VoIPQualityIndicator</name>
-                                <type>String(255)</type>
+                                <type>string(255)</type>
                                 <syntax>string</syntax>
                             </parameter>
                             <parameter>
                                 <name>WorstVoIPQualityIndicatorsValues</name>
-                                <type>String(255)</type>
+                                <type>string(255)</type>
                                 <syntax>string</syntax>
                             </parameter>
                             <parameter>
                                 <name>WorstVoIPQualityIndicatorTimestamps</name>
-                                <type>String(255)</type>
+                                <type>string(255)</type>
                                 <syntax>string</syntax>
                             </parameter>
                         </parameters>
@@ -5578,7 +5578,7 @@
                 </parameter>
                 <parameter>
                     <name>Name</name>
-                    <type>String(64)</type>
+                    <type>string(64)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
@@ -5602,7 +5602,7 @@
                 </parameter>
                 <parameter>
                     <name>QIModelUsed</name>
-                    <type>String(128)</type>
+                    <type>string(128)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
@@ -5756,7 +5756,7 @@
                         </parameter>
                         <parameter>
                             <name>LocalCName</name>
-                            <type>String(64)</type>
+                            <type>string(64)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -5788,7 +5788,7 @@
                         </parameter>
                         <parameter>
                             <name>EncryptionKeySizes</name>
-                            <type>String(255)</type>
+                            <type>string(255)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -5925,12 +5925,12 @@
                 </parameter>
                 <parameter>
                     <name>Codec</name>
-                    <type>String(256)</type>
+                    <type>string(256)</type>
                     <syntax>string</syntax>
                 </parameter>
                 <parameter>
                     <name>PacketizationPeriod</name>
-                    <type>String(255)</type>
+                    <type>string(255)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
@@ -5952,7 +5952,7 @@
             <parameters>
                 <parameter>
                     <name>DefautEventProfile</name>
-                    <type>String(256)</type>
+                    <type>string(256)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
@@ -5992,19 +5992,19 @@
                     </parameter>
                     <parameter>
                         <name>ToneName</name>
-                        <type>String(64)</type>
+                        <type>string(64)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>TonePattern</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
                     <parameter>
                         <name>ToneFile</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -6016,7 +6016,7 @@
                     </parameter>
                     <parameter>
                         <name>ToneText</name>
-                        <type>String(64)</type>
+                        <type>string(64)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -6130,7 +6130,7 @@
                     </parameter>
                     <parameter>
                         <name>NextPattern</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -6184,13 +6184,13 @@
                         </parameter>
                          <parameter>
                              <name>Function</name>
-                             <type>String(255)</type>
+                             <type>string(255)</type>
                              <syntax>string</syntax>
                              <writable>true</writable>
                          </parameter>
                          <parameter>
                              <name>Tone</name>
-                             <type>String(256)</type>
+                             <type>string(256)</type>
                              <syntax>string</syntax>
                              <writable>true</writable>
                          </parameter>
@@ -6244,7 +6244,7 @@
                 </parameter>
                 <parameter>
                     <name>ToneEventProfile</name>
-                    <type>String(256)</type>
+                    <type>string(256)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
@@ -6274,7 +6274,7 @@
                     </parameter>
                     <parameter>
                         <name>Name</name>
-                        <type>String(256)</type>
+                        <type>string(256)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -6353,30 +6353,30 @@
                         </parameter>
                         <parameter>
                             <name>ButtonName</name>
-                            <type>String(16)</type>
+                            <type>string(16)</type>
                             <syntax>string</syntax>
                         </parameter>
                         <parameter>
                             <name>FacilityAction</name>
-                            <type>String(64)</type>
+                            <type>string(64)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
                         <parameter>
                             <name>FacilityActionArgument</name>
-                            <type>String(256)</type>
+                            <type>string(256)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
                         <parameter>
                             <name>QuickDialNumber</name>
-                            <type>String(40)</type>
+                            <type>string(40)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
                         <parameter>
                             <name>ButtonMessage</name>
-                            <type>String(64)</type>
+                            <type>string(64)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -6426,19 +6426,19 @@
                         </parameter>
                         <parameter>
                             <name>RingName</name>
-                            <type>String(64)</type>
+                            <type>string(64)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
                         <parameter>
                             <name>RingPattern</name>
-                            <type>String(256)</type>
+                            <type>string(256)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
                         <parameter>
                             <name>RingFile</name>
-                            <type>String(256)</type>
+                            <type>string(256)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -6490,7 +6490,7 @@
                         </parameter>
                         <parameter>
                             <name>NextPattern</name>
-                            <type>String(256)</type>
+                            <type>string(256)</type>
                             <syntax>string</syntax>
                             <writable>true</writable>
                         </parameter>
@@ -6517,7 +6517,7 @@
                     </parameter>
                     <parameter>
                         <name>TestSelector</name>
-                        <type>String(255)</type>
+                        <type>string(255)</type>
                         <syntax>string</syntax>
                         <writable>true</writable>
                     </parameter>
@@ -6547,13 +6547,13 @@
             <parameters>
                 <parameter>
                     <name>CurrentSource</name>
-                    <type>String(256)</type>
+                    <type>string(256)</type>
                     <syntax>string</syntax>
                     <writable>true</writable>
                 </parameter>
                 <parameter>
                     <name>Description</name>
-                    <type>String(64)</type>
+                    <type>string(64)</type>
                     <syntax>string</syntax>
                 </parameter>
                 <parameter>
@@ -6604,7 +6604,7 @@
                             </parameter>
                             <parameter>
                                 <name>Interface</name>
-                                <type>String(256)</type>
+                                <type>string(256)</type>
                                 <syntax>string</syntax>
                                 <writable>true</writable>
                             </parameter>


### PR DESCRIPTION
Reason for change :

When setting parameters where the string length exceeds the defined maximum (e.g., >256), the following is observed:
The request is accepted.
The system returns Success instead of a validation error.
```Execution fail(error code:CCSP_ERR_INVALID_PARAMETER_VALUE(9007)). ```

Test procedure:
    - Build compiled successfully.

Risks: low

Priority: P1

Signed-off-by: Mohamadou Sanogo mohamadou.sanogo@sagemcom.com